### PR TITLE
Fix jalali_is_jleap function

### DIFF
--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -63,6 +63,12 @@ extern char* tzname[2];
 
 int jalali_is_jleap(int year)
 {
+    // A simple way to check if it is a leap year
+    if (year % 4 == 3){
+        return 1;
+    }
+    return 0;
+
     int pr = year;
 
     /* Shifting ``year'' with 2820 year period epoch. */


### PR DESCRIPTION
This year (1403) is a leap year which jcal won't recognize it. I read the jalali_is_jleap function code which employed some complicated logic that I did not understand, So I came up with the idea that if a year mod 4 would be 3, it would be a leap year, so I changed the function so that it only checks this simple condition. I hope my oversimplification does not miss out on some details I don't know.