### PR TITLE
Replace leap year algorithm with the list of leap years

### DIFF
--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -52,71 +52,50 @@ const int accumulated_jalali_month_len[] = { 0, 31, 62, 93, 124, 155, 186,
 extern char* tzname[2];
 
 /*
- * Jalali leap year indication function. The algorithm used here
- * is loosely based on the famous recurring 2820 years length period. This
- * period is then divided into 88 cycles, each following a 29, 33, 33, 33
- * years length pattern with the exception for the last being 37 years long.
- * In every of these 29, 33 or 37 years long periods starting with year 0,
- * leap years are multiples of four except for year 0 in each period.
- * The current 2820 year period started in the year AP 475 (AD 1096).
+ * Jalali leap year indication function.
+ *
+ * There aren’t enough reasons to implement astronomical algorithms in
+ * this function. Someone else has already done the calculations, so we
+ * can just use their results here. Hopefully, someone will update this
+ * list of leap years in the next century ;-)
  */
 
 int jalali_is_jleap(int year)
 {
-    int pr = year;
+    /* Leap years from 1200 to 1299 AP */
+    int leap1200[100] = {
+        [10] = 1, [14] = 1, [18] = 1, [22] = 1, [26] = 1, [30] = 1,
+        [34] = 1, [38] = 1, [43] = 1, [47] = 1, [51] = 1, [55] = 1,
+        [59] = 1, [63] = 1, [67] = 1, [71] = 1, [76] = 1, [80] = 1,
+        [84] = 1, [88] = 1, [92] = 1, [96] = 1
+    };
 
-    /* Shifting ``year'' with 2820 year period epoch. */
-    pr -= JALALI_LEAP_BASE;
+    /* Leap years from 1300 to 1399 AP */
+    int leap1300[100] = {
+        [0]  = 1, [4]  = 1, [9]  = 1, [13] = 1, [17] = 1, [21] = 1,
+        [25] = 1, [29] = 1, [33] = 1, [37] = 1, [42] = 1, [46] = 1,
+        [50] = 1, [54] = 1, [58] = 1, [62] = 1, [66] = 1, [70] = 1,
+        [75] = 1, [79] = 1, [83] = 1, [87] = 1, [91] = 1, [95] = 1,
+        [99] = 1
+    };
 
-    pr %= JALALI_LEAP_PERIOD;
+    /* Leap years from 1400 to 1499 AP */
+    int leap1400[100] = {
+        [3]  = 1, [8]  = 1, [12] = 1, [16] = 1, [20] = 1, [24] = 1,
+        [28] = 1, [32] = 1, [36] = 1, [41] = 1, [45] = 1, [49] = 1,
+        [53] = 1, [57] = 1, [61] = 1, [65] = 1, [69] = 1, [74] = 1,
+        [78] = 1, [82] = 1, [86] = 1, [90] = 1, [94] = 1
+    };
 
-    /*
-     * According to C99 standards, modulo operator's result has the same sign
-     * as dividend. Since what we require to process has to be in range
-     * 0-2819, we have to shift the remainder to be positive if dividend is
-     * negative.
-     */
-    if (pr < 0) {
-        pr += JALALI_LEAP_PERIOD;
-    }
+    int i = year % 100;
 
-    /*
-     * Every cycle consists of one 29 year period and three identical 33 year
-     * periods forming a 128 years length cycle. An exception applies to the
-     * last cycle being 132 years instead and it's last 33 years long partition
-     * will be extended for an extra 4 years thus becoming 37 years long.
-     * JALALI_LAST_CYCLE_START literally marks the beginning of this last
-     * cycle.
-     */
+    if(year >= 1200 && year <= 1299 && leap1200[i] == 1)
+            return 1;
+    else if(year >= 1300 && year <= 1399 && leap1300[i] == 1)
+            return 1;
+    else if(year >= 1400 && year <= 1499 && leap1400[i] == 1)
+            return 1;
 
-    pr = (pr > JALALI_LAST_CYCLE_START) ?
-        (pr - JALALI_LAST_CYCLE_START) : pr % JALALI_NORMAL_CYCLE_LENGTH;
-
-    /*
-     * Classifying year in a cycle. Assigning to one of the four partitions.
-     */
-    int i;
-    for (i=0; i<J_LI; i++)
-    {
-        if ((pr >= cycle_patterns[i]) && (pr < cycle_patterns[i+1]))
-        {
-            pr -= cycle_patterns[i];
-            /* Handling year-0 exception */
-            if (!pr) /* pr is zero */
-                return 0;
-            /*
-             * If year is a multiple of four then it's leap,
-             * ordinary otherwise.
-             */
-            else
-                return !(pr % J_LI);
-        }
-    }
-
-    /*
-     * Our code flow better not reach this fail-safe
-     * return statement and I really mean it.
-     */
     return 0;
 }
 

--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -142,7 +142,7 @@ int jalali_is_jleap(int year)
     /*
      * Classifying year in a cycle. Assigning to one of the four partitions.
      */
-    int i;
+
     for (i=0; i<J_LI; i++)
     {
         if ((pr >= cycle_patterns[i]) && (pr < cycle_patterns[i+1]))

--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -52,16 +52,18 @@ const int accumulated_jalali_month_len[] = { 0, 31, 62, 93, 124, 155, 186,
 extern char* tzname[2];
 
 /*
- * Jalali leap year indication function.
- *
- * There aren’t enough reasons to implement astronomical algorithms in
- * this function. Someone else has already done the calculations, so we
- * can just use their results here. Hopefully, someone will update this
- * list of leap years in the next century ;-)
+ * Jalali leap year indication function. The algorithm used here
+ * is loosely based on the famous recurring 2820 years length period. This
+ * period is then divided into 88 cycles, each following a 29, 33, 33, 33
+ * years length pattern with the exception for the last being 37 years long.
+ * In every of these 29, 33 or 37 years long periods starting with year 0,
+ * leap years are multiples of four except for year 0 in each period.
+ * The current 2820 year period started in the year AP 475 (AD 1096).
  */
 
 int jalali_is_jleap(int year)
 {
+
     /* Leap years from 1200 to 1299 AP */
     int leap1200[100] = {
         [10] = 1, [14] = 1, [18] = 1, [22] = 1, [26] = 1, [30] = 1,
@@ -89,13 +91,79 @@ int jalali_is_jleap(int year)
 
     int i = year % 100;
 
-    if(year >= 1200 && year <= 1299 && leap1200[i] == 1)
+    if(year >= 1200 && year <= 1299) {
+        if(leap1200[i] == 1)
             return 1;
-    else if(year >= 1300 && year <= 1399 && leap1300[i] == 1)
+        else
+            return 0;
+    } else if(year >= 1300 && year <= 1399) {
+        if(leap1300[i] == 1)
             return 1;
-    else if(year >= 1400 && year <= 1499 && leap1400[i] == 1)
+        else
+            return 0;
+    } else if(year >= 1400 && year <= 1499) {
+        if(leap1400[i] == 1)
             return 1;
+        else
+            return 0;
+    }
 
+    /* Keeping the old algorithm as fallback */
+
+    int pr = year;
+
+    /* Shifting ``year'' with 2820 year period epoch. */
+    pr -= JALALI_LEAP_BASE;
+
+    pr %= JALALI_LEAP_PERIOD;
+
+    /*
+     * According to C99 standards, modulo operator's result has the same sign
+     * as dividend. Since what we require to process has to be in range
+     * 0-2819, we have to shift the remainder to be positive if dividend is
+     * negative.
+     */
+    if (pr < 0) {
+        pr += JALALI_LEAP_PERIOD;
+    }
+
+    /*
+     * Every cycle consists of one 29 year period and three identical 33 year
+     * periods forming a 128 years length cycle. An exception applies to the
+     * last cycle being 132 years instead and it's last 33 years long partition
+     * will be extended for an extra 4 years thus becoming 37 years long.
+     * JALALI_LAST_CYCLE_START literally marks the beginning of this last
+     * cycle.
+     */
+
+    pr = (pr > JALALI_LAST_CYCLE_START) ?
+        (pr - JALALI_LAST_CYCLE_START) : pr % JALALI_NORMAL_CYCLE_LENGTH;
+
+    /*
+     * Classifying year in a cycle. Assigning to one of the four partitions.
+     */
+    int i;
+    for (i=0; i<J_LI; i++)
+    {
+        if ((pr >= cycle_patterns[i]) && (pr < cycle_patterns[i+1]))
+        {
+            pr -= cycle_patterns[i];
+            /* Handling year-0 exception */
+            if (!pr) /* pr is zero */
+                return 0;
+            /*
+             * If year is a multiple of four then it's leap,
+             * ordinary otherwise.
+             */
+            else
+                return !(pr % J_LI);
+        }
+    }
+
+    /*
+     * Our code flow better not reach this fail-safe
+     * return statement and I really mean it.
+     */
     return 0;
 }
 


### PR DESCRIPTION
Previous implementation of jalali_is_jleap has bug in these years:
1209,1210,1242,1243,1403,1404,1436,1437,1469,1470
So I decided to replace the algorithm with the list of leap years from https://web.archive.org/web/20230712052459if_/https://calendar.ut.ac.ir/Fa/News/Data/Doc/KabiseShamsi1206-1498-new.pdf