### PR TITLE
Change links in man pages to point to this repo, update version to 0.5.1

### DIFF
--- a/sources/configure.ac
+++ b/sources/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([jcal], [0.4], [ghassemi@ftml.net])
+AC_INIT([jcal], [0.4], [https://github.com/persiancal/jcal])
 
 AM_INIT_AUTOMAKE
 AC_PROG_LIBTOOL

--- a/sources/configure.ac
+++ b/sources/configure.ac
@@ -1,7 +1,7 @@
 #                                               -*- Autoconf -*-
 # Process this file with autoconf to produce a configure script.
 
-AC_INIT([jcal], [0.4], [https://github.com/persiancal/jcal])
+AC_INIT([jcal], [0.5.1], [https://github.com/persiancal/jcal])
 
 AM_INIT_AUTOMAKE
 AC_PROG_LIBTOOL

--- a/sources/man/jcal.1
+++ b/sources/man/jcal.1
@@ -156,8 +156,8 @@ No other versions rumor to exist.
 .Sh AUTHOR
 Written by Ashkan Ghassemi. <ghassemi@ftml.net>
 .Sh REPORTING BUGS
-Report jcal bugs to <ghassemi@ftml.net>
-libjalali home page: <http://savannah.nongnu.org/projects/jcal/>
+Report jcal bugs to <https://github.com/persiancal/jcal/issues>
+libjalali home page: <https://github.com/persiancal/jcal>
 .Sh SEE ALSO
 .Nm jdate (1),
 .Nm jctime (3),

--- a/sources/man/jctime.3
+++ b/sources/man/jctime.3
@@ -493,9 +493,9 @@ This page is part of release 0.2 of the libjalali
 .SH AUTHOR
 Written by Ashkan Ghassemi. <ghassemi@ftml.net>
 .SH REPORTING BUGS
-Report libjalali bugs to <ghassemi@ftml.net>
+Report libjalali bugs to <https://github.com/persiancal/jcal/issues>
 
-libjalali home page: <http://savannah.nongnu.org/projects/jcal/>
+libjalali home page: <https://github.com/persiancal/jcal>
 .SH COPYRIGHT
 Copyright (C) 2011 Ashkan Ghassemi.
 

--- a/sources/man/jdate.1
+++ b/sources/man/jdate.1
@@ -209,9 +209,9 @@ displays seconds since epoch (UTC) for local date specified by date string.
 .SH AUTHOR
 Written by Ashkan Ghassemi. <ghassemi@ftml.net>
 .SH REPORTING BUGS
-Report jdate bugs to <ghassemi@ftml.net>
+Report jdate bugs to <https://github.com/persiancal/jcal/issues>
 
-libjalali home page: <http://savannah.nongnu.org/projects/jcal/>
+libjalali home page: <https://github.com/persiancal/jcal>
 .SH "SEE ALSO"
 .BR jcal (1),
 .BR jctime (3),

--- a/sources/man/jstrftime.3
+++ b/sources/man/jstrftime.3
@@ -308,9 +308,9 @@ This page is part of release 0.2 of the libjalali
 .SH AUTHOR
 Written by Ashkan Ghassemi. <ghassemi@ftml.net>
 .SH REPORTING BUGS
-Report libjalali bugs to <ghassemi@ftml.net>
+Report libjalali bugs to <https://github.com/persiancal/jcal/issues>
 
-libjalali home page: <http://savannah.nongnu.org/projects/jcal/>
+libjalali home page: <https://github.com/persiancal/jcal>
 .SH COPYRIGHT
 Copyright (C) 2011 Ashkan Ghassemi.
 

--- a/sources/man/jstrptime.3
+++ b/sources/man/jstrptime.3
@@ -195,9 +195,9 @@ This page is part of release 0.2 of the libjalali
 .SH AUTHOR
 Written by Ashkan Ghassemi. <ghassemi@ftml.net>
 .SH REPORTING BUGS
-Report libjalali bugs to <ghassemi@ftml.net>
+Report libjalali bugs to <https://github.com/persiancal/jcal/issues>
 
-libjalali home page: <http://savannah.nongnu.org/projects/jcal/>
+libjalali home page: <https://github.com/persiancal/jcal>
 .SH COPYRIGHT
 Copyright (C) 2011 Ashkan Ghassemi.
 


### PR DESCRIPTION
Since the email mentioned in the man pages for bug reports is no longer accessible and the version on http://savannah.nongnu.org/projects/jcal/ is outdated and showing the wrong date (at least until next year when the leap years cancel out), I think we should point to this repo instead.
Also I changed the version shown by `jcal -V` in `configure.ac` file to `0.5.1`