### PR TITLE
Support out-of-tree build to keep source tree clean of build artifacts

### DIFF
--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = jcal jdate
 
-INCLUDES = -I. -I.. -I../libjalali -I@includedir@
+INCLUDES = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall\
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
-INCLUDES = -I../../libjalali
+INCLUDES = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
-INCLUDES = -I../../libjalali
+INCLUDES = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE


### PR DESCRIPTION
Replace relative paths in `Makefile.am` files with `${top_srcdir}`.
Now it is possible to build the project in an out of tree dir like:
```
      ├── jcal
      └── build-jcal
cd jcal/sources;
./autogen.sh;
cd ../../build-jcal;
../jcal/sources/configure;
make;
```