### PR TITLE
Remove math.h from jalali.c

### DIFF
--- a/sources/libjalali/jalali.c
+++ b/sources/libjalali/jalali.c
@@ -21,7 +21,6 @@
 
 #include <stdio.h>
 #include <limits.h>
-#include <math.h>
 #include <time.h>
 #include <stdlib.h>
 #include <sys/time.h>


### PR DESCRIPTION
libjalali has included math header for no reason. Probably, this was added with a assumption that `abs` or some other function is a part of math while it isn't.