### PR TITLE
Make whatis entry usefull.

### DIFF
--- a/sources/man/jdate.1
+++ b/sources/man/jdate.1
@@ -21,7 +21,7 @@
 
 .TH JDATE "1" "Khordad 6, 1390" "jdate" "User Commands"
 .SH NAME
-jdate \- manual page for jdate
+jdate \- Show Jalai date
 .SH SYNOPSIS
 .B jdate
 [\fIarRuhV\fR]... [\fI+OUTPUT_FORMAT\fR][\fId INPUT_FORMAT;DATE_STRING\fR]


### PR DESCRIPTION
The current brief description found in the NAME section of man page conveys no information about what the program is for and is repetitive. The short description should contain brief information about what the program is for to aid in searching with apropos and similar programs.