### PR TITLE
Add a minimalistic linter action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,17 @@
+name: clang-format Check
+on: [push, pull_request]
+jobs:
+  formatting-check:
+    name: Formatting Check
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+      fail-fast: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run clang-format style check for C/C++/Protobuf programs.
+        uses: jidicula/clang-format-action@v4.15.0
+        with:
+          clang-format-version: "19" # latest on Archlinux as of committing
+          check-path: "sources"

--- a/sources/CONTRIBUTION.md
+++ b/sources/CONTRIBUTION.md
@@ -1,4 +1,6 @@
 # Contribution Guide
 
-It is suggested for the new contributors to use the following tools:
-- `clang-format` for all the C files, source and headers.
+This project enforces (see [workflows](../.github/workflows/)) the following
+formatters:
+- `clang-format` version 19 for all the C files, source and headers (or any
+  protobuf if any, in the future).


### PR DESCRIPTION
This action, triggered on push or pull, fails if clang-format fails. This addresses the comment referenced by [1] on #28 (formatting all the sources following the minimal path examples on #23).

Note that the "sources" directory is hardcoded on the action file pushed. Assuming the change of source directory is a fundamental change with a lot of considerations, no documentations were added to mention that the value used in this file must be synchronized with the directory name on the tree. Suppose this comment suffices.

After a bit of thinking, I realized adding a hook (as I previously suggested in [my comment](https://github.com/persiancal/jcal/pull/28#issuecomment-2829930891)) is not a fit solution since it is hard to enforce on the user because of Git policies and still it just helps the developers not the maintainers so after a long 2 page scroll on Google I decided on this piece of work.

There is this [run](https://github.com/Davoodeh/jcal/actions/runs/14662846294) on my [`workflow-lint-test-example`](https://github.com/Davoodeh/jcal/tree/refs/heads/workflow-lint-test-example) as a failure example which may prove useful to study. 

P.S: I also tested [Super Linter](https://github.com/marketplace/actions/super-linter) which is really wholesome in every sense but it is also too bloated just like [Pre-Commit](https://pre-commit.com/) and honestly, after second 30 of build I scraped everything so I have no idea, maybe that is good too! Regardless, I don't think "checking" should take more time than "building", if that makes any sense. Since we have only C parts formatted yet, we can settle for this and consider expanding on this later. Or alternatively, all the Python and shell files will be removed before that day.

[1]: https://github.com/persiancal/jcal/pull/28#issuecomment-2823474321