### PR TITLE
Clean up Automake files

### DIFF
--- a/sources/CONTRIBUTION.md
+++ b/sources/CONTRIBUTION.md
@@ -2,3 +2,6 @@
 
 It is suggested for the new contributors to use the following tools:
 - `clang-format` for all the C files, source and headers.
+
+The codebase is better compiled and checked with `-Wall`. Ideally, no warning
+should show.

--- a/sources/Makefile.am
+++ b/sources/Makefile.am
@@ -1,5 +1,5 @@
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS         = libjalali src man test_kit
+SUBDIRS = libjalali src man test_kit
 
 if WANT_PYJALALI
 install-exec-hook:

--- a/sources/Makefile.am
+++ b/sources/Makefile.am
@@ -3,16 +3,14 @@ SUBDIRS         = libjalali src man test_kit
 
 if WANT_PYJALALI
 install-exec-hook:
-	@echo -e "\n###########################\n"\
-"##  Installing Pyjalali  ##\n"\
-"###########################\n"
+	@printf "Installing PyJalali"
 	test -d pyjalali || mkdir pyjalali
-	@$(CP) $(srcdir)/pyjalali/*.py pyjalali
-	@$(CP) $(srcdir)/setup.py .
+	@cp $(srcdir)/pyjalali/*.py pyjalali
+	@cp $(srcdir)/setup.py .
 	LIBJALALI_DIR=$(DESTDIR)$(libdir) \
 	$(PYTHON) setup.py install --prefix=$(DESTDIR)$(exec_prefix) --record=pyinstalled.txt
 
 uninstall-hook:
-	while read -r fn; do $(RM) -rf "$$fn"; done <pyinstalled.txt
-	-$(RMDIR) $(DESTDIR)$(pythondir)/pyjalali && $(RM) pyinstalled.txt
+	while read -r fn; do rm -rf "$$fn"; done <pyinstalled.txt
+	-rmdir $(DESTDIR)$(pythondir)/pyjalali && rm pyinstalled.txt
 endif

--- a/sources/configure.ac
+++ b/sources/configure.ac
@@ -11,9 +11,6 @@ AC_CONFIG_MACRO_DIR([m4])
 AC_PROG_CC
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
-AC_PATH_PROG(CP, cp, /bin/cp)
-AC_PATH_PROG(RM, rm, /bin/rm)
-AC_PATH_PROG(RMDIR, rmdir, /bin/rmdir)
 
 # Checks for header files.
 AC_CHECK_HEADERS([time.h limits.h stdlib.h string.h sys/time.h unistd.h])
@@ -65,8 +62,5 @@ if test $installpyjalali = "yes"; then
                 AM_PATH_PYTHON
 fi
 AM_CONDITIONAL([WANT_PYJALALI], [test $installpyjalali = "yes"])
-
-AC_PATH_PROG(RM, rm, $FALSE)
-RM="$RM -f"
 
 AC_OUTPUT

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,5 +17,5 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-AM_CFLAGS       = @CFLAGS@ -Wall -O2
+AM_CFLAGS       = @CFLAGS@ -Wall
 AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,4 +17,3 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,5 +17,4 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-AM_CFLAGS       = @CFLAGS@ -Wall
 AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,6 +17,5 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-LIBS            = @LIBS@ $(THREAD_LIBS)
 AM_CFLAGS          = @CFLAGS@ -D_REENTRANT -W -Wall -O2
 AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,6 +17,6 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-INCLUDES        =  -I. -I@includedir@
 LIBS            = @LIBS@ $(THREAD_LIBS)
 AM_CFLAGS          = @CFLAGS@ -D_REENTRANT -W -Wall -O2
+AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -15,5 +15,5 @@ libjalali_la_SOURCES = jalali.c jtime.c
 #      example...)
 
 libjalali_la_LDFLAGS = -version-info 0:5:0
-includedir= $(prefix)/include/jalali
+includedir = $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,5 +17,5 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-AM_CFLAGS          = @CFLAGS@ -W -Wall -O2
+AM_CFLAGS       = @CFLAGS@ -Wall -O2
 AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/libjalali/Makefile.am
+++ b/sources/libjalali/Makefile.am
@@ -17,5 +17,5 @@ libjalali_la_SOURCES = jalali.c jtime.c
 libjalali_la_LDFLAGS = -version-info 0:5:0
 includedir= $(prefix)/include/jalali
 include_HEADERS = jalali.h jtime.h jconfig.h
-AM_CFLAGS          = @CFLAGS@ -D_REENTRANT -W -Wall -O2
+AM_CFLAGS          = @CFLAGS@ -W -Wall -O2
 AM_CPPFLAGS     =  -I. -I@includedir@

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jcal jdate
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall\
+AM_CFLAGS = @CFLAGS@ -fno-inline -Wall\
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jcal_SOURCES = jcal.c

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -2,8 +2,7 @@ bin_PROGRAMS = jcal jdate
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
-AM_CFLAGS = @CFLAGS@ -Wall\
-	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jcal_SOURCES = jcal.c
 jdate_SOURCES = jdate.c

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jcal jdate
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
-AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
 
 jcal_SOURCES = jcal.c
 jdate_SOURCES = jdate.c

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -1,7 +1,5 @@
 bin_PROGRAMS = jcal jdate
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
-
 AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
 
 jcal_SOURCES = jcal.c

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -8,4 +8,3 @@ AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall\
 jcal_SOURCES = jcal.c
 jdate_SOURCES = jdate.c
 LDADD           = ../libjalali/libjalali.la -L@libdir@
-LIBS            = @LIBS@ $(THREAD_LIBS)

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jcal jdate
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -Wall\
+AM_CFLAGS = @CFLAGS@ -Wall\
 	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jcal_SOURCES = jcal.c

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = jcal jdate
 
-INCLUDES = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall\
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -4,4 +4,4 @@ AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
 
 jcal_SOURCES = jcal.c
 jdate_SOURCES = jdate.c
-LDADD           = ../libjalali/libjalali.la -L@libdir@
+LDADD = ../libjalali/libjalali.la -L@libdir@

--- a/sources/src/Makefile.am
+++ b/sources/src/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = jcal jdate
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/libjalali -I@includedir@
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -Wall\
-	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jcal_SOURCES = jcal.c
 jdate_SOURCES = jdate.c

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
-	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 elc_SOURCES = elc.c
 get_date_SOURCES = get_date.c

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
-INCLUDES = -I${top_srcdir}/libjalali
+AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -12,4 +12,4 @@ jyinfo_SOURCES = jyinfo.c
 leap_SOURCES = leap.c
 sec_converter_SOURCES = sec_converter.c
 
-LDADD           = ../../libjalali/libjalali.la
+LDADD = ../../libjalali/libjalali.la

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
+AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 elc_SOURCES = elc.c

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
 
 elc_SOURCES = elc.c
 get_date_SOURCES = get_date.c

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -2,8 +2,7 @@ bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -Wall \
-	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 elc_SOURCES = elc.c
 get_date_SOURCES = get_date.c

--- a/sources/test_kit/jalali/Makefile.am
+++ b/sources/test_kit/jalali/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = elc get_date get_diff jalali_update jyinfo leap sec_converter
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
+AM_CFLAGS = @CFLAGS@ -Wall \
 	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 elc_SOURCES = elc.c

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -12,4 +12,4 @@ jstrptime_SOURCES = jstrptime.c
 jlocaltime_SOURCES = jlocaltime.c
 jmktime_SOURCES = jmktime.c
 
-LDADD           = ../../libjalali/libjalali.la -lreadline
+LDADD = ../../libjalali/libjalali.la -lreadline

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
+AM_CFLAGS = @CFLAGS@ -Wall \
 	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jasctime_SOURCES = jasctime.c

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -1,6 +1,6 @@
 bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
-INCLUDES = -I${top_srcdir}/libjalali
+AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -3,7 +3,7 @@ bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
 AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
-	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jasctime_SOURCES = jasctime.c
 jctime_SOURCES = jctime.c

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_TIME_BITS=64
 
 jasctime_SOURCES = jasctime.c
 jctime_SOURCES = jctime.c

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -2,7 +2,7 @@ bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -fno-inline -D_REENTRANT -Wall \
+AM_CFLAGS = @CFLAGS@ -fno-inline -Wall \
 	-O2 -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jasctime_SOURCES = jasctime.c

--- a/sources/test_kit/jtime/Makefile.am
+++ b/sources/test_kit/jtime/Makefile.am
@@ -2,8 +2,7 @@ bin_PROGRAMS = jasctime jctime jgmtime jstrftime jstrptime jlocaltime jmktime
 
 AM_CPPFLAGS = -I${top_srcdir}/libjalali
 
-AM_CFLAGS = @CFLAGS@ -Wall \
-	-D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
+AM_CFLAGS = @CFLAGS@ -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE
 
 jasctime_SOURCES = jasctime.c
 jctime_SOURCES = jctime.c


### PR DESCRIPTION
Documented in detail in commits and descriptions.

As with before, this should not change the behavior and builds with no problem. Written with Automake (GNU) 1.17 in mind.

In an overview:
- Update obsolete codes
- Remove undocumented variables and codes that seem dead (at least I believe they must stay removed till documented).
- Remove hardcoded flags that mostly are user's concern
- Step closer to Y2038 immunity
- Format slightly better (just space removal in a couple of instances)

In one instance, `configure.ac` is touched since it cannot be cleaned in isolation. The programs are removed since presumably they are always in modern computers at least according to GNU books and standards.